### PR TITLE
JSON comparison path option tests

### DIFF
--- a/code/testutils/src/test/java/com/adobe/marketing/mobile/util/JSONAssertsPathOptionsTests.kt
+++ b/code/testutils/src/test/java/com/adobe/marketing/mobile/util/JSONAssertsPathOptionsTests.kt
@@ -892,4 +892,204 @@ class JSONAssertsPathOptionsTests {
         assertExactMatch(expected, actual, CollectionEqualCount(isActive = false))
         assertTypeMatch(expected, actual, CollectionEqualCount(isActive = false))
     }
+
+    @Test
+    fun testCollectionEqualCount_WithDefaultInit_CorrectlyFails() {
+        val expected = "{}"
+        val actual = """
+        {
+          "key1": 1
+        }
+        """
+
+        assertFailsWith<AssertionError>("Validation should fail when collection counts are not equal") {
+            assertTypeMatch(expected, actual, CollectionEqualCount())
+        }
+    }
+
+    @Test
+    fun testKeyMustBeAbsent_WithDefaultInit_CorrectlyFails() {
+        val expected = "{}"
+        val actual = """
+        {
+          "key1": 1
+        }
+        """
+
+        assertFailsWith<AssertionError>("Validation should fail when key name is present") {
+            assertTypeMatch(expected, actual, KeyMustBeAbsent("key1"))
+        }
+    }
+
+    @Test
+    fun testKeyMustBeAbsent_WithInnerPath_CorrectlyFails() {
+        val expected = "{}"
+        val actual = """
+        {
+          "events": [
+            {
+              "request": {
+                "path": "something"
+              }
+            }
+          ],
+          "path": "top level"
+        }
+        """
+
+        assertFailsWith<AssertionError>("Validation should fail when key names not provided") {
+            assertTypeMatch(expected, actual, KeyMustBeAbsent("events[*].request.path"))
+        }
+    }
+
+    @Test
+    fun testKeyMustBeAbsent_WithSinglePath_Passes() {
+        val expected = "{}"
+        val actual = """
+        {
+            "key1": 1
+        }
+        """
+
+        assertExactMatch(expected, actual, KeyMustBeAbsent("key2"))
+    }
+
+    @Test
+    fun testKeyMustBeAbsent_WithMultipleKeys_Passes() {
+        val expected = "{}"
+        val actual = """
+        {
+            "key1": 1
+        }
+        """
+
+        assertExactMatch(expected, actual, KeyMustBeAbsent("key2", "key3"))
+    }
+
+    @Test
+    fun testKeyMustBeAbsent_Fails_WhenKeyPresent() {
+        val expected = "{}"
+        val actual = """
+        {
+            "key1": 1
+        }
+        """
+
+        assertFailsWith<AssertionError>("Validation should fail when key that must be absent is present in actual") {
+            assertExactMatch(expected, actual, KeyMustBeAbsent("key1"))
+        }
+    }
+
+    @Test
+    fun testKeyMustBeAbsent_worksWhenKeyInDifferentHierarchy() {
+        val expected = """
+        {
+          "key1": 1
+        }
+        """
+        val actual = """
+        {
+          "key1": 1,
+          "key2": {
+            "key3": 1
+          }
+        }
+        """
+
+        assertFailsWith<AssertionError>("Validation should fail when key that must be absent is present in actual") {
+            assertExactMatch(expected, actual, KeyMustBeAbsent("key2.key3"))
+        }
+    }
+
+    @Test
+    fun testValueExactMatch_WithDefaultPathsInit_CorrectlyFails() {
+        val expected = """
+        {
+            "key1": 1
+        }
+        """
+        val actual = """
+        {
+            "key1": 2
+        }
+        """
+
+        assertFailsWith<AssertionError>("Validation should fail when path option is not satisfied") {
+            assertTypeMatch(expected, actual, ValueExactMatch(scope = Subtree))
+        }
+    }
+
+    @Test
+    fun testValueTypeMatch_WithDefaultPathsInit_Passes() {
+        val expected = """
+        {
+            "key1": 1
+        }
+        """
+        val actual = """
+        {
+            "key1": 2
+        }
+        """
+
+        assertExactMatch(expected, actual, ValueTypeMatch(scope = Subtree))
+    }
+
+    @Test
+    fun testValueTypeMatch_SubtreeOption_Propagates() {
+        val expected = """
+        {
+          "key0-0": [
+            {
+              "key1-0": 1
+            }
+          ]
+        }
+        """
+        val actual = """
+        {
+          "key0-0": [
+            {
+              "key1-0": 2
+            }
+          ]
+        }
+        """
+
+        assertExactMatch(expected, actual, ValueTypeMatch("key0-0", scope = Subtree))
+    }
+
+    @Test
+    fun testValueTypeMatch_SingleNodeAndSubtreeOption() {
+        val expected = """
+        {
+          "key0-0": [
+            {
+              "key1-0": 1
+            }
+          ],
+          "key0-1": 1
+        }
+        """
+        val actual = """
+        {
+          "key0-0": [
+            {
+              "key1-0": 2
+            }
+          ],
+          "key0-1": 2
+        }
+        """
+
+        assertExactMatch(expected, actual, ValueTypeMatch("key0-1"), ValueTypeMatch("key0-0", scope = Subtree))
+    }
+
+    @Test
+    fun testValueExactMatch_WithDefaultInit_CorrectlyFails() {
+        val expected = "[1, 2]"
+        val actual = "[2, 1]"
+
+        assertExactMatch(expected, actual, AnyOrderMatch())
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR converts the [path option tests from iOS](https://github.com/adobe/aepsdk-testutils-ios/blob/main/Tests/UnitTests/AnyCodablePathOptionsTests.swift), introduced in PR: https://github.com/adobe/aepsdk-testutils-ios/pull/15

At a high level it covers two main areas:
1. General path option behavior works as expected - things like:
    1. Node scope comparison: SingleNode vs Subtree.
    2. Application of multiple options simultaneously.
    3. Option overriding.
    4. Specifying multiple paths for a single option.
2. Specific path option behavior works as expected
    1. AnyOrderMatch
    2. CollectionEqualCount
    3. KeyMustBeAbsent

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
