### PR TITLE
Rename JSON comparison `assertEqual` to `assertEquals`

### DIFF
--- a/code/testutils/src/main/java/com/adobe/marketing/mobile/util/JSONAsserts.kt
+++ b/code/testutils/src/main/java/com/adobe/marketing/mobile/util/JSONAsserts.kt
@@ -27,7 +27,7 @@ object JSONAsserts {
      * @throws AssertionError If the [expected] and [actual] JSON structures are not exactly equal.
      */
     @JvmStatic
-    fun assertEqual(expected: Any?, actual: Any?) {
+    fun assertEquals(expected: Any?, actual: Any?) {
         if (expected == null && actual == null) {
             return
         }

--- a/code/testutils/src/test/java/com/adobe/marketing/mobile/util/JSONAssertsDeprecatedAPITests.kt
+++ b/code/testutils/src/test/java/com/adobe/marketing/mobile/util/JSONAssertsDeprecatedAPITests.kt
@@ -11,7 +11,7 @@
 
 package com.adobe.marketing.mobile.util
 
-import com.adobe.marketing.mobile.util.JSONAsserts.assertEqual
+import com.adobe.marketing.mobile.util.JSONAsserts.assertEquals
 import com.adobe.marketing.mobile.util.JSONAsserts.assertExactMatch
 import com.adobe.marketing.mobile.util.JSONAsserts.assertTypeMatch
 import org.json.JSONArray
@@ -28,7 +28,7 @@ class JSONAssertsDeprecatedAPITests {
         val expected = null
         val actual = null
 
-        assertEqual(expected, actual)
+        assertEquals(expected, actual)
     }
 
     // Alternate path tests - assertEqual does not handle alternate paths and is not tested here

--- a/code/testutils/src/test/java/com/adobe/marketing/mobile/util/JSONAssertsParameterizedTests.kt
+++ b/code/testutils/src/test/java/com/adobe/marketing/mobile/util/JSONAssertsParameterizedTests.kt
@@ -11,7 +11,7 @@
 
 package com.adobe.marketing.mobile.util
 
-import com.adobe.marketing.mobile.util.JSONAsserts.assertEqual
+import com.adobe.marketing.mobile.util.JSONAsserts.assertEquals
 import com.adobe.marketing.mobile.util.JSONAsserts.assertExactMatch
 import com.adobe.marketing.mobile.util.JSONAsserts.assertTypeMatch
 import org.json.JSONArray
@@ -91,7 +91,7 @@ class JSONAssertsParameterizedTests {
 
         @Test
         fun `should match basic values`() {
-            assertEqual(params.expected, params.actual)
+            assertEquals(params.expected, params.actual)
             assertExactMatch(params.expected, params.actual)
             assertTypeMatch(params.expected, params.actual)
         }
@@ -124,7 +124,7 @@ class JSONAssertsParameterizedTests {
 
         @Test
         fun `should match basic values`() {
-            assertEqual(params.expected, params.actual)
+            assertEquals(params.expected, params.actual)
             assertExactMatch(params.expected, params.actual)
             assertTypeMatch(params.expected, params.actual)
         }
@@ -158,7 +158,7 @@ class JSONAssertsParameterizedTests {
 
         @Test
         fun `should match basic values`() {
-            assertEqual(params.expected, params.actual)
+            assertEquals(params.expected, params.actual)
             assertExactMatch(params.expected, params.actual)
             assertTypeMatch(params.expected, params.actual)
         }
@@ -185,7 +185,7 @@ class JSONAssertsParameterizedTests {
         @Test
         fun `should match only by type for values of the same type`() {
             Assert.assertThrows(AssertionError::class.java) {
-                assertEqual(params.expected, params.actual)
+                assertEquals(params.expected, params.actual)
             }
             Assert.assertThrows(AssertionError::class.java) {
                 assertExactMatch(params.expected, params.actual)
@@ -213,7 +213,7 @@ class JSONAssertsParameterizedTests {
         @Test
         fun `should pass flexible matching when expected is a subset`() {
             assertFailsWith<AssertionError>("Validation should fail when collection sizes are different.") {
-                assertEqual(params.expected, params.actual)
+                assertEquals(params.expected, params.actual)
             }
             assertExactMatch(params.expected, params.actual)
             assertTypeMatch(params.expected, params.actual)
@@ -262,7 +262,7 @@ class JSONAssertsParameterizedTests {
         @Test
         fun `should detect type mismatch or nullability issues`() {
             assertFailsWith<AssertionError>("Validation should fail when value types mismatch.") {
-                assertEqual(params.expected, params.actual)
+                assertEquals(params.expected, params.actual)
             }
             assertFailsWith<AssertionError>("Validation should fail when value types mismatch.") {
                 assertTypeMatch(params.expected, params.actual)
@@ -299,7 +299,7 @@ class JSONAssertsParameterizedTests {
 
         @Test
         fun `should handle special characters in JSON keys correctly`() {
-            assertEqual(params.expected, params.actual)
+            assertEquals(params.expected, params.actual)
             assertExactMatch(params.expected, params.actual)
             assertTypeMatch(params.expected, params.actual)
         }
@@ -489,7 +489,7 @@ class JSONAssertsParameterizedTests {
         @Test
         fun `should error on larger expected arrays`() {
             assertFailsWith<AssertionError>("Validation should fail when expected array is larger regardless of alternate paths.") {
-                assertEqual(params.expected, params.actual)
+                assertEquals(params.expected, params.actual)
             }
             assertFailsWith<AssertionError>("Validation should fail when exact matching is enforced with larger expected arrays.") {
                 assertExactMatch(params.expected, params.actual, ValueTypeMatch(keyPaths))
@@ -526,7 +526,7 @@ class JSONAssertsParameterizedTests {
         @Test
         fun `should error on larger expected maps`() {
             Assert.assertThrows(AssertionError::class.java) {
-                assertEqual(params.expected, params.actual)
+                assertEquals(params.expected, params.actual)
             }
             Assert.assertThrows(AssertionError::class.java) {
                 assertExactMatch(params.expected, params.actual, ValueTypeMatch(keyPaths))


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR renames the JSON comparison API `assertEqual` to `assertEquals` to better align with Java/Kotlin style test assertions.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
