### PR TITLE
Define MultiPathConfig constructor permutations for Java

### DIFF
--- a/code/testutils/src/main/java/com/adobe/marketing/mobile/util/NodeConfig.kt
+++ b/code/testutils/src/main/java/com/adobe/marketing/mobile/util/NodeConfig.kt
@@ -83,7 +83,12 @@ data class AnyOrderMatch(
     override val config: NodeConfig.Config = NodeConfig.Config(isActive = true),
     override val scope: NodeConfig.Scope = NodeConfig.Scope.SingleNode
 ) : MultiPathConfig {
+    companion object {
+        private val defaultPaths = listOf(null)
+        private val defaultScope = NodeConfig.Scope.SingleNode
+    }
 
+    // Secondary constructor permutations are explicitly defined for Java compatibility
     /**
      * Initializes a new instance with an array of paths.
      *
@@ -91,10 +96,28 @@ data class AnyOrderMatch(
      * @param isActive Boolean value indicating whether the configuration is active.
      * @param scope The scope of configuration, defaulting to single node.
      */
-    @JvmOverloads
     constructor(paths: List<String?> = listOf(null), isActive: Boolean = true, scope: NodeConfig.Scope = NodeConfig.Scope.SingleNode) :
         this(paths, config = NodeConfig.Config(isActive = isActive), scope = scope)
 
+    constructor(isActive: Boolean = true, scope: NodeConfig.Scope = NodeConfig.Scope.SingleNode) :
+        this(defaultPaths, isActive, scope)
+
+    constructor(paths: List<String?>, scope: NodeConfig.Scope) :
+        this(paths, true, scope)
+
+    constructor(paths: List<String?>, isActive: Boolean) :
+        this(paths, isActive, defaultScope)
+
+    constructor(paths: List<String?>) :
+        this(paths, true)
+
+    constructor(isActive: Boolean) :
+        this(defaultPaths, isActive)
+
+    constructor(scope: NodeConfig.Scope) :
+        this(defaultPaths, scope)
+
+    // Variadic initializers rely on their List<*> constructor counterparts
     /**
      * Variadic initializer allowing multiple string paths.
      *
@@ -102,13 +125,17 @@ data class AnyOrderMatch(
      * @param isActive Boolean value indicating whether the configuration is active.
      * @param scope The scope of configuration, defaulting to single node.
      */
-    @JvmOverloads
     constructor(vararg paths: String?, isActive: Boolean = true, scope: NodeConfig.Scope = NodeConfig.Scope.SingleNode) :
-        this(
-            if (paths.isEmpty()) listOf(null) else paths.toList(),
-            isActive = isActive,
-            scope = scope
-        )
+        this(if (paths.isEmpty()) defaultPaths else paths.toList(), isActive, scope)
+
+    constructor(vararg paths: String?, scope: NodeConfig.Scope) :
+        this(if (paths.isEmpty()) defaultPaths else paths.toList(), scope)
+
+    constructor(vararg paths: String?, isActive: Boolean) :
+        this(if (paths.isEmpty()) defaultPaths else paths.toList(), isActive)
+
+    constructor(vararg paths: String?) :
+        this(if (paths.isEmpty()) defaultPaths else paths.toList())
 }
 
 /**
@@ -120,6 +147,10 @@ data class CollectionEqualCount(
     override val config: NodeConfig.Config = NodeConfig.Config(isActive = true),
     override val scope: NodeConfig.Scope = NodeConfig.Scope.SingleNode
 ) : MultiPathConfig {
+    companion object {
+        private val defaultPaths = listOf(null)
+        private val defaultScope = NodeConfig.Scope.SingleNode
+    }
 
     /**
      * Secondary constructor for initializing with a list of paths.
@@ -128,24 +159,46 @@ data class CollectionEqualCount(
      * @param isActive Boolean value indicating whether the configuration is active.
      * @param scope The scope of configuration, defaulting to single node.
      */
-    @JvmOverloads
     constructor(paths: List<String?> = listOf(null), isActive: Boolean = true, scope: NodeConfig.Scope = NodeConfig.Scope.SingleNode) :
         this(paths, config = NodeConfig.Config(isActive = isActive), scope = scope)
 
+    constructor(isActive: Boolean = true, scope: NodeConfig.Scope = NodeConfig.Scope.SingleNode) :
+        this(defaultPaths, isActive, scope)
+
+    constructor(paths: List<String?>, scope: NodeConfig.Scope) :
+        this(paths, true, scope)
+
+    constructor(paths: List<String?>, isActive: Boolean) :
+        this(paths, isActive, defaultScope)
+
+    constructor(paths: List<String?>) :
+        this(paths, true)
+
+    constructor(isActive: Boolean) :
+        this(defaultPaths, isActive)
+
+    constructor(scope: NodeConfig.Scope) :
+        this(defaultPaths, scope)
+
+    // Variadic initializers rely on their List<*> constructor counterparts
     /**
      * Variadic initializer allowing multiple string paths.
      *
      * @param paths Vararg of optional path strings.
-     * @param isActive Specifies whether this configuration is active.
-     * @param scope Specifies the scope of the configuration.
+     * @param isActive Boolean value indicating whether the configuration is active.
+     * @param scope The scope of configuration, defaulting to single node.
      */
-    @JvmOverloads
     constructor(vararg paths: String?, isActive: Boolean = true, scope: NodeConfig.Scope = NodeConfig.Scope.SingleNode) :
-        this(
-            if (paths.isEmpty()) listOf(null) else paths.toList(),
-            isActive = isActive,
-            scope = scope
-        )
+        this(if (paths.isEmpty()) defaultPaths else paths.toList(), isActive, scope)
+
+    constructor(vararg paths: String?, scope: NodeConfig.Scope) :
+        this(if (paths.isEmpty()) defaultPaths else paths.toList(), scope)
+
+    constructor(vararg paths: String?, isActive: Boolean) :
+        this(if (paths.isEmpty()) defaultPaths else paths.toList(), isActive)
+
+    constructor(vararg paths: String?) :
+        this(if (paths.isEmpty()) defaultPaths else paths.toList())
 }
 
 /**
@@ -157,6 +210,10 @@ data class KeyMustBeAbsent(
     override val config: NodeConfig.Config = NodeConfig.Config(isActive = true),
     override val scope: NodeConfig.Scope = NodeConfig.Scope.SingleNode
 ) : MultiPathConfig {
+    companion object {
+        private val defaultPaths = listOf(null)
+        private val defaultScope = NodeConfig.Scope.SingleNode
+    }
 
     /**
      * Initializes a new instance with an array of paths.
@@ -165,24 +222,46 @@ data class KeyMustBeAbsent(
      * @param isActive Boolean value indicating whether the configuration is active.
      * @param scope The scope of configuration, defaulting to single node.
      */
-    @JvmOverloads
     constructor(paths: List<String?> = listOf(null), isActive: Boolean = true, scope: NodeConfig.Scope = NodeConfig.Scope.SingleNode) :
-        this(paths, NodeConfig.OptionKey.KeyMustBeAbsent, NodeConfig.Config(isActive = isActive), scope)
+        this(paths, config = NodeConfig.Config(isActive = isActive), scope = scope)
 
+    constructor(isActive: Boolean = true, scope: NodeConfig.Scope = NodeConfig.Scope.SingleNode) :
+        this(defaultPaths, isActive, scope)
+
+    constructor(paths: List<String?>, scope: NodeConfig.Scope) :
+        this(paths, true, scope)
+
+    constructor(paths: List<String?>, isActive: Boolean) :
+        this(paths, isActive, defaultScope)
+
+    constructor(paths: List<String?>) :
+        this(paths, true)
+
+    constructor(isActive: Boolean) :
+        this(defaultPaths, isActive)
+
+    constructor(scope: NodeConfig.Scope) :
+        this(defaultPaths, scope)
+
+    // Variadic initializers rely on their List<*> constructor counterparts
     /**
      * Variadic initializer allowing multiple string paths.
      *
-     * @param paths Vararg of optional path strings. When empty, defaults to a list containing null.
-     * @param isActive Specifies whether this configuration is active.
-     * @param scope Specifies the scope of the configuration.
+     * @param paths Vararg of optional path strings.
+     * @param isActive Boolean value indicating whether the configuration is active.
+     * @param scope The scope of configuration, defaulting to single node.
      */
-    @JvmOverloads
     constructor(vararg paths: String?, isActive: Boolean = true, scope: NodeConfig.Scope = NodeConfig.Scope.SingleNode) :
-        this(
-            if (paths.isEmpty()) listOf(null) else paths.toList(),
-            isActive = isActive,
-            scope = scope
-        )
+        this(if (paths.isEmpty()) defaultPaths else paths.toList(), isActive, scope)
+
+    constructor(vararg paths: String?, scope: NodeConfig.Scope) :
+        this(if (paths.isEmpty()) defaultPaths else paths.toList(), scope)
+
+    constructor(vararg paths: String?, isActive: Boolean) :
+        this(if (paths.isEmpty()) defaultPaths else paths.toList(), isActive)
+
+    constructor(vararg paths: String?) :
+        this(if (paths.isEmpty()) defaultPaths else paths.toList())
 }
 
 /**
@@ -201,30 +280,56 @@ data class ValueExactMatch(
     override val config: NodeConfig.Config = NodeConfig.Config(isActive = true),
     override val scope: NodeConfig.Scope = NodeConfig.Scope.SingleNode
 ) : MultiPathConfig {
-
+    companion object {
+        private val defaultPaths = listOf(null)
+        private val defaultScope = NodeConfig.Scope.SingleNode
+    }
     /**
      * Secondary constructor for initializing with a list of paths.
      *
      * @param paths A list of optional path strings, defaults to a list containing null if no paths are provided.
      * @param scope The scope of configuration, typically single node or subtree.
      */
-    @JvmOverloads
-    constructor(paths: List<String?> = listOf(null), scope: NodeConfig.Scope = NodeConfig.Scope.SingleNode) :
-        this(paths, config = NodeConfig.Config(isActive = true), scope = scope)
+    constructor(paths: List<String?> = listOf(null), isActive: Boolean = true, scope: NodeConfig.Scope = NodeConfig.Scope.SingleNode) :
+        this(paths, config = NodeConfig.Config(isActive = isActive), scope = scope)
 
+    constructor(isActive: Boolean = true, scope: NodeConfig.Scope = NodeConfig.Scope.SingleNode) :
+        this(defaultPaths, isActive, scope)
+
+    constructor(paths: List<String?>, scope: NodeConfig.Scope) :
+        this(paths, true, scope)
+
+    constructor(paths: List<String?>, isActive: Boolean) :
+        this(paths, isActive, defaultScope)
+
+    constructor(paths: List<String?>) :
+        this(paths, true)
+
+    constructor(isActive: Boolean) :
+        this(defaultPaths, isActive)
+
+    constructor(scope: NodeConfig.Scope) :
+        this(defaultPaths, scope)
+
+    // Variadic initializers rely on their List<*> constructor counterparts
     /**
-     * Variadic constructor allowing multiple string paths. This constructor handles empty path inputs
-     * by creating a list containing a single null element, ensuring consistent validation behavior.
+     * Variadic initializer allowing multiple string paths.
      *
-     * @param paths Vararg of optional path strings, defaults to a list containing null when empty.
-     * @param scope Specifies the scope of the configuration, typically single node or subtree.
+     * @param paths Vararg of optional path strings.
+     * @param isActive Boolean value indicating whether the configuration is active.
+     * @param scope The scope of configuration, defaulting to single node.
      */
-    @JvmOverloads
-    constructor(vararg paths: String?, scope: NodeConfig.Scope = NodeConfig.Scope.SingleNode) :
-        this(
-            if (paths.isEmpty()) listOf(null) else paths.toList(),
-            scope = scope
-        )
+    constructor(vararg paths: String?, isActive: Boolean = true, scope: NodeConfig.Scope = NodeConfig.Scope.SingleNode) :
+        this(if (paths.isEmpty()) defaultPaths else paths.toList(), isActive, scope)
+
+    constructor(vararg paths: String?, scope: NodeConfig.Scope) :
+        this(if (paths.isEmpty()) defaultPaths else paths.toList(), scope)
+
+    constructor(vararg paths: String?, isActive: Boolean) :
+        this(if (paths.isEmpty()) defaultPaths else paths.toList(), isActive)
+
+    constructor(vararg paths: String?) :
+        this(if (paths.isEmpty()) defaultPaths else paths.toList())
 }
 
 /**
@@ -236,29 +341,56 @@ data class ValueTypeMatch(
     override val config: NodeConfig.Config = NodeConfig.Config(isActive = false),
     override val scope: NodeConfig.Scope = NodeConfig.Scope.SingleNode
 ) : MultiPathConfig {
-
+    companion object {
+        private val defaultPaths = listOf(null)
+        private val defaultScope = NodeConfig.Scope.SingleNode
+    }
     /**
      * Initializes a new instance with an array of paths.
      *
      * @param paths A list of optional path strings, defaults to a list containing null if no paths are provided.
      * @param scope The scope of configuration, typically single node or subtree.
      */
-    @JvmOverloads
-    constructor(paths: List<String?> = listOf(null), scope: NodeConfig.Scope = NodeConfig.Scope.SingleNode) :
-        this(paths, config = NodeConfig.Config(isActive = false), scope = scope)
+    constructor(paths: List<String?> = listOf(null), isActive: Boolean = false, scope: NodeConfig.Scope = NodeConfig.Scope.SingleNode) :
+        this(paths, config = NodeConfig.Config(isActive = isActive), scope = scope)
 
+    constructor(isActive: Boolean = false, scope: NodeConfig.Scope = NodeConfig.Scope.SingleNode) :
+        this(defaultPaths, isActive, scope)
+
+    constructor(paths: List<String?>, scope: NodeConfig.Scope) :
+        this(paths, false, scope)
+
+    constructor(paths: List<String?>, isActive: Boolean) :
+        this(paths, isActive, defaultScope)
+
+    constructor(paths: List<String?>) :
+        this(paths, false)
+
+    constructor(isActive: Boolean) :
+        this(defaultPaths, isActive)
+
+    constructor(scope: NodeConfig.Scope) :
+        this(defaultPaths, scope)
+
+    // Variadic initializers rely on their List<*> constructor counterparts
     /**
      * Variadic initializer allowing multiple string paths.
      *
-     * @param paths Vararg of optional path strings, defaults to a list containing null when empty.
-     * @param scope Specifies the scope of the configuration, typically single node or subtree.
+     * @param paths Vararg of optional path strings.
+     * @param isActive Boolean value indicating whether the configuration is active.
+     * @param scope The scope of configuration, defaulting to single node.
      */
-    @JvmOverloads
-    constructor(vararg paths: String?, scope: NodeConfig.Scope = NodeConfig.Scope.SingleNode) :
-        this(
-            if (paths.isEmpty()) listOf(null) else paths.toList(),
-            scope = scope
-        )
+    constructor(vararg paths: String?, isActive: Boolean = false, scope: NodeConfig.Scope = NodeConfig.Scope.SingleNode) :
+        this(if (paths.isEmpty()) defaultPaths else paths.toList(), isActive, scope)
+
+    constructor(vararg paths: String?, scope: NodeConfig.Scope) :
+        this(if (paths.isEmpty()) defaultPaths else paths.toList(), scope)
+
+    constructor(vararg paths: String?, isActive: Boolean) :
+        this(if (paths.isEmpty()) defaultPaths else paths.toList(), isActive)
+
+    constructor(vararg paths: String?) :
+        this(if (paths.isEmpty()) defaultPaths else paths.toList())
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR improves the Java usability of secondary constructors by explicitly defining all permutations of parameters instead of relying on the constructor list provided by `@JvmOverloads`.

For example, the constructors provided by `@JvmOverloads` are the following:
```kotlin
@JvmOverloads
constructor(paths: List<String?> = listOf(null), isActive: Boolean = true, scope: NodeConfig.Scope = NodeConfig.Scope.SingleNode) :
        this(paths, config = NodeConfig.Config(isActive = isActive), scope = scope)

public CollectionEqualCount(List<String> paths) { ... }
public CollectionEqualCount(List<String> paths, boolean isActive) { ... }
public CollectionEqualCount(List<String> paths, boolean isActive, NodeConfig.Scope scope) { ... }
```

In Kotlin, it is possible to rely on default parameter values and set only the arguments for values that are not defaults.

However, in Java, based on the provided secondary constructors, it is not possible to define just the scope argument without having to re-specify all the other parameters that come before it, which adds a lot of boilerplate and makes the code more cumbersome to use:

```java
new CollectionEqualCount(Collections.singletonList((String) null), true, NodeConfig.Scope.Subtree)
```

With the changes from this PR, the following usage is now possible:

```java
new CollectionEqualCount(NodeConfig.Scope.Subtree)
```


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
