### PR TITLE
Add MockConnection class from Edge + MockNetworkService connectAsync counter

### DIFF
--- a/code/testutils/src/main/java/com/adobe/marketing/mobile/util/MockConnection.java
+++ b/code/testutils/src/main/java/com/adobe/marketing/mobile/util/MockConnection.java
@@ -1,0 +1,96 @@
+/*
+  Copyright 2024 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.util;
+
+import com.adobe.marketing.mobile.services.HttpConnecting;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Map;
+
+public class MockConnection implements HttpConnecting {
+
+	public MockConnection(final int responseCode, final String responseBody, final String errorBody) {
+		this(responseCode, responseBody, errorBody, null);
+	}
+
+	public MockConnection(
+		final int responseCode,
+		final String responseBody,
+		final String errorBody,
+		final Map<String, String> headers
+	) {
+		mockGetResponseCode = responseCode;
+		mockResponseBody = responseBody;
+		mockErrorBody = errorBody;
+		mockGetResponsePropertyValues = headers;
+	}
+
+	public int getInputStreamCalledTimes = 0;
+	private String mockResponseBody;
+
+	@Override
+	public InputStream getInputStream() {
+		getInputStreamCalledTimes += 1;
+
+		if (mockResponseBody == null) {
+			return null;
+		}
+
+		return new ByteArrayInputStream(mockResponseBody.getBytes());
+	}
+
+	public int getErrorStreamCalledTimes = 0;
+	private String mockErrorBody;
+
+	@Override
+	public InputStream getErrorStream() {
+		getErrorStreamCalledTimes += 1;
+
+		if (mockErrorBody == null) {
+			return null;
+		}
+
+		return new ByteArrayInputStream(mockErrorBody.getBytes());
+	}
+
+	public int getResponseCodeCalledTimes = 0;
+	private int mockGetResponseCode = 0;
+
+	@Override
+	public int getResponseCode() {
+		getResponseCodeCalledTimes += 1;
+		return mockGetResponseCode;
+	}
+
+	@Override
+	public String getResponseMessage() {
+		return null;
+	}
+
+	private Map<String, String> mockGetResponsePropertyValues;
+
+	@Override
+	public String getResponsePropertyValue(final String value) {
+		if (mockGetResponsePropertyValues == null) {
+			return null;
+		}
+
+		return mockGetResponsePropertyValues.get(value);
+	}
+
+	public int closeCalledTimes = 0;
+
+	@Override
+	public void close() {
+		closeCalledTimes += 1;
+	}
+}

--- a/code/testutils/src/main/java/com/adobe/marketing/mobile/util/MockNetworkService.kt
+++ b/code/testutils/src/main/java/com/adobe/marketing/mobile/util/MockNetworkService.kt
@@ -40,6 +40,14 @@ class MockNetworkService : Networking {
             // If this assumption changes, this flag logic needs to be updated.
             return helper.networkRequests.isNotEmpty()
         }
+    /**
+     * How many times the [connectAsync] method was called.
+     * Note that this property does not await and returns the value immediately.
+     */
+    val connectAsyncCalledTimes: Int
+        get() {
+            return helper.networkRequests.count()
+        }
     // Simulating the async network service
     private val executorService: ExecutorService = Executors.newCachedThreadPool()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR brings over the MockConnection class from Edge and updates the MockNetworkService class to include a new property that returns the number of times the connectAsync method was called.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
