### PR TITLE
Update MockNetworkService to allow for setting the default response

### DIFF
--- a/code/testutils/src/main/java/com/adobe/marketing/mobile/util/NetworkRequestHelper.kt
+++ b/code/testutils/src/main/java/com/adobe/marketing/mobile/util/NetworkRequestHelper.kt
@@ -32,9 +32,9 @@ class NetworkRequestHelper {
     // Read-only access to network requests
     val networkRequests: List<NetworkRequest>
         get() = _networkRequests
-    private val _networkResponses: MutableMap<TestableNetworkRequest, MutableList<HttpConnecting>> = HashMap()
+    private val _networkResponses: MutableMap<TestableNetworkRequest, MutableList<HttpConnecting?>> = HashMap()
     // Read-only access to network responses
-    val networkResponses: Map<TestableNetworkRequest, MutableList<HttpConnecting>>
+    val networkResponses: Map<TestableNetworkRequest, MutableList<HttpConnecting?>>
         get() = _networkResponses
     private val expectedNetworkRequests: MutableMap<TestableNetworkRequest, ADBCountDownLatch> = HashMap()
 
@@ -146,7 +146,7 @@ class NetworkRequestHelper {
      */
     fun addResponseFor(
         request: NetworkRequest,
-        responseConnection: HttpConnecting
+        responseConnection: HttpConnecting?
     ) {
         val testableRequest = TestableNetworkRequest(request)
         if (_networkResponses[testableRequest] != null) {
@@ -174,7 +174,7 @@ class NetworkRequestHelper {
      * @return The list of [HttpConnecting] responses for the given request or `null` if not found.
      * @see [TestableNetworkRequest.equals] for the logic used to match network requests.
      */
-    fun getResponsesFor(request: NetworkRequest): List<HttpConnecting>? {
+    fun getResponsesFor(request: NetworkRequest): List<HttpConnecting?>? {
         return _networkResponses[TestableNetworkRequest(request)]
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR updates the MockNetworkService to allow for setting null responses for a request and update connectAsync callback logic to properly return the value including null if set, only using the default if no response has been set for that request.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
