### PR TITLE
Create new path option `ValueNotEqual`

### DIFF
--- a/code/testutils/src/main/java/com/adobe/marketing/mobile/util/JSONAsserts.kt
+++ b/code/testutils/src/main/java/com/adobe/marketing/mobile/util/JSONAsserts.kt
@@ -16,6 +16,7 @@ import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.fail
 
 object JSONAsserts {
@@ -46,7 +47,7 @@ object JSONAsserts {
             return
         }
         // Exact equality is just a special case of exact match
-        assertExactMatch(expected, actual, CollectionEqualCount(isActive = true, scope = NodeConfig.Scope.Subtree))
+        assertExactMatch(expected, actual, CollectionEqualCount(true, NodeConfig.Scope.Subtree))
     }
 
     /**
@@ -104,7 +105,8 @@ object JSONAsserts {
             AnyOrderMatch(isActive = false),
             CollectionEqualCount(isActive = false),
             KeyMustBeAbsent(isActive = false),
-            ValueTypeMatch()
+            ValueTypeMatch(),
+            ValueNotEqual(isActive = false)
         )
         validate(expected, actual, pathOptions.toList(), treeDefaults)
     }
@@ -219,7 +221,8 @@ object JSONAsserts {
             AnyOrderMatch(isActive = false),
             CollectionEqualCount(isActive = false),
             KeyMustBeAbsent(isActive = false),
-            ValueExactMatch()
+            ValueExactMatch(),
+            ValueNotEqual(isActive = false)
         )
         validate(expected, actual, pathOptions.toList(), treeDefaults)
     }
@@ -326,7 +329,7 @@ object JSONAsserts {
             if (shouldAssert) {
                 fail(
                     """
-                    Expected JSON is non-nil but Actual JSON is nil.
+                    Expected JSON is non-null but Actual JSON is null.
                     Expected: $expected
                     Actual: $actual
                     Key path: ${keyPathAsString(keyPath)}
@@ -341,7 +344,19 @@ object JSONAsserts {
                 expected is Boolean && actual is Boolean ||
                 expected is Int && actual is Int ||
                 expected is Double && actual is Double -> {
-                if (nodeTree.primitiveExactMatch.isActive) {
+                if (nodeTree.valueNotEqual.isActive) {
+                    if (shouldAssert) assertNotEquals(
+                        """
+                        Expected and Actual values should not be equal.
+                        Expected: $expected (Type: ${expected::class.qualifiedName})
+                        Actual: $actual (Type: ${actual::class.qualifiedName})
+                        Key path: ${keyPathAsString(keyPath)}
+                        """.trimIndent(),
+                        expected,
+                        actual
+                    )
+                    expected != actual
+                } else if (nodeTree.primitiveExactMatch.isActive) {
                     if (shouldAssert) assertEquals(
                         "Key path: ${keyPathAsString(keyPath)}",
                         expected,
@@ -370,7 +385,7 @@ object JSONAsserts {
                 if (shouldAssert) {
                     fail(
                         """
-                        Expected and Actual types do not match.
+                        Expected and Actual types are not the same.
                         Expected: $expected (Type: ${expected::class.qualifiedName})
                         Actual: $actual (Type: ${actual::class.qualifiedName})
                         Key path: ${keyPathAsString(keyPath)}
@@ -407,7 +422,7 @@ object JSONAsserts {
             if (shouldAssert) {
                 fail(
                     """
-                Expected JSON is non-nil but Actual JSON is nil.
+                Expected JSON is non-null but Actual JSON is null.
     
                 Expected: $expected
     
@@ -554,7 +569,7 @@ object JSONAsserts {
             if (shouldAssert) {
                 fail(
                     """
-                    Expected JSON is non-nil but Actual JSON is nil.
+                    Expected JSON is non-null but Actual JSON is null.
         
                     Expected: $expected
                     

--- a/code/testutils/src/main/java/com/adobe/marketing/mobile/util/NodeConfig.kt
+++ b/code/testutils/src/main/java/com/adobe/marketing/mobile/util/NodeConfig.kt
@@ -267,6 +267,70 @@ data class KeyMustBeAbsent(
 }
 
 /**
+ * Validation option which specifies: values must have the same type but the literal values must not be equal.
+ */
+data class ValueNotEqual(
+    override val config: NodeConfig.Config = NodeConfig.Config(isActive = true),
+    override val scope: NodeConfig.Scope = NodeConfig.Scope.SingleNode,
+    override val paths: List<String?> = listOf(null),
+    override val optionKey: NodeConfig.OptionKey = NodeConfig.OptionKey.ValueNotEqual,
+) : MultiPathConfig {
+    companion object {
+        private val defaultPaths = listOf(null)
+        private val defaultScope = NodeConfig.Scope.SingleNode
+    }
+
+    /**
+     * Initializes a new instance with the specified parameters.
+     *
+     * @param isActive Boolean value indicating whether the configuration is active.
+     * @param scope The scope of configuration, defaulting to single node.
+     * @param paths A list of optional path strings.
+     */
+    constructor(isActive: Boolean = true, scope: NodeConfig.Scope = NodeConfig.Scope.SingleNode, paths: List<String?> = defaultPaths) :
+        this(NodeConfig.Config(isActive = isActive), scope, paths)
+
+    // Secondary constructor permutations are explicitly defined for Java compatibility
+    constructor(isActive: Boolean, paths: List<String?>) :
+        this(isActive, defaultScope, paths)
+
+    constructor(scope: NodeConfig.Scope, paths: List<String?>) :
+        this(true, scope, paths)
+
+    constructor(isActive: Boolean, scope: NodeConfig.Scope) :
+        this(isActive, scope, defaultPaths)
+
+    constructor(isActive: Boolean) :
+        this(isActive, defaultPaths)
+
+    constructor(scope: NodeConfig.Scope) :
+        this(scope, defaultPaths)
+
+    constructor(paths: List<String?>) :
+        this(defaultScope, paths)
+
+    // Variadic initializers rely on their List<*> constructor counterparts
+    /**
+     * Variadic initializer allowing multiple string paths.
+     *
+     * @param isActive Boolean value indicating whether the configuration is active.
+     * @param scope The scope of configuration, defaulting to single node.
+     * @param paths Vararg of optional path strings.
+     */
+    constructor(isActive: Boolean = true, scope: NodeConfig.Scope = NodeConfig.Scope.SingleNode, vararg paths: String?) :
+        this(isActive, scope, if (paths.isEmpty()) defaultPaths else paths.toList())
+
+    constructor(isActive: Boolean, vararg paths: String?) :
+        this(isActive, if (paths.isEmpty()) defaultPaths else paths.toList())
+
+    constructor(scope: NodeConfig.Scope, vararg paths: String?) :
+        this(scope, if (paths.isEmpty()) defaultPaths else paths.toList())
+
+    constructor(vararg paths: String?) :
+        this(if (paths.isEmpty()) defaultPaths else paths.toList())
+}
+
+/**
  * Validation option which specifies that values must have the same type and literal value.
  * This class applies to specified paths within a data structure, ensuring that values at these paths
  * are exactly the same both in type and value.
@@ -383,8 +447,9 @@ class NodeConfig {
     enum class OptionKey(val value: String) {
         AnyOrderMatch("AnyOrderMatch"),
         CollectionEqualCount("CollectionEqualCount"),
+        KeyMustBeAbsent("KeyMustBeAbsent"),
         PrimitiveExactMatch("PrimitiveExactMatch"),
-        KeyMustBeAbsent("KeyMustBeAbsent")
+        ValueNotEqual("ValueNotEqual")
     }
 
     /**
@@ -447,6 +512,10 @@ class NodeConfig {
     var primitiveExactMatch: Config
         get() = options[OptionKey.PrimitiveExactMatch] ?: subtreeOptions[OptionKey.PrimitiveExactMatch]!!
         set(value) { options[OptionKey.PrimitiveExactMatch] = value }
+
+    var valueNotEqual: Config
+        get() = options[OptionKey.ValueNotEqual] ?: subtreeOptions[OptionKey.ValueNotEqual]!!
+        set(value) { options[OptionKey.ValueNotEqual] = value }
 
     /**
      * Creates a new node with the given values.
@@ -520,6 +589,8 @@ class NodeConfig {
                     node?.keyMustBeAbsent ?: node?.wildcardChildren?.keyMustBeAbsent ?: parentNode.keyMustBeAbsent
                 OptionKey.PrimitiveExactMatch ->
                     node?.primitiveExactMatch ?: node?.wildcardChildren?.primitiveExactMatch ?: parentNode.primitiveExactMatch
+                OptionKey.ValueNotEqual ->
+                    node?.valueNotEqual ?: node?.wildcardChildren?.valueNotEqual ?: parentNode.valueNotEqual
             }
         }
     }

--- a/code/testutils/src/test/java/com/adobe/marketing/mobile/util/JSONAssertsPathOptionsTests.kt
+++ b/code/testutils/src/test/java/com/adobe/marketing/mobile/util/JSONAssertsPathOptionsTests.kt
@@ -1093,4 +1093,136 @@ class JSONAssertsPathOptionsTests {
 
         assertExactMatch(expected, actual, AnyOrderMatch())
     }
+
+    @Test
+    fun testValueNotEqual_withDictionarySpecificKey_passes() {
+        val expected = """{ "key": "value" }"""
+        val actual = """{ "key": "different" }"""
+
+        assertExactMatch(expected, actual, ValueNotEqual("key"))
+    }
+
+    @Test
+    fun testValueNotEqual_withDictionaryUnsatisfiedKey_fails() {
+        val expected = """
+        {
+          "key1": "value",
+          "key2": "value"
+        }
+        """
+        val actual = """
+        {
+          "key1": "different",
+          "key2": "different"
+        }
+        """
+
+        assertFailsWith<AssertionError>("Validation should fail when path option is not satisfied") {
+            assertExactMatch(expected, actual, ValueNotEqual("key1"))
+        }
+    }
+
+    @Test
+    fun testValueNotEqual_withDictionarySingleNodeScope_passes() {
+        val expected = """
+        {
+          "key1": "value",
+          "key2": {
+            "key3": "value"
+          }
+        }
+        """
+        val actual = """
+        {
+          "key1": "different",
+          "key2": {
+            "key3": "value"
+          }
+        }
+        """
+
+        assertExactMatch(expected, actual, ValueNotEqual("*"))
+    }
+
+    @Test
+    fun testValueNotEqual_withDictionarySubtreeScope_passes() {
+        val expected = """
+        {
+          "key1": "value",
+          "key2": {
+            "key3": "value"
+          }
+        }
+        """
+        val actual = """
+        {
+          "key1": "different",
+          "key2": {
+            "key3": "different"
+          }
+        }
+        """
+
+        assertExactMatch(expected, actual, ValueNotEqual(Subtree))
+    }
+
+    @Test
+    fun testValueNotEqual_withDictionaryWildcardKey_passes() {
+        val expected = """
+        {
+          "key1": "value",
+          "key2": "value"
+        }
+        """
+        val actual = """
+        {
+          "key1": "different",
+          "key2": "different"
+        }
+        """
+
+        assertExactMatch(expected, actual, ValueNotEqual("*"))
+    }
+
+    @Test
+    fun testValueNotEqual_withArraySpecificIndex_passes() {
+        val expected = "[1]"
+        val actual = "[2]"
+
+        assertExactMatch(expected, actual, ValueNotEqual("[0]"))
+    }
+
+    @Test
+    fun testValueNotEqual_withArrayUnsatisfiedIndex_passes() {
+        val expected = "[1, 1]"
+        val actual = "[2, 2]"
+
+        assertFailsWith<AssertionError>("Validation should fail when path option is not satisfied") {
+            assertExactMatch(expected, actual, ValueNotEqual("[0]"))
+        }
+    }
+
+    @Test
+    fun testValueNotEqual_withArrayWildcardIndex_passes() {
+        val expected = "[1, 1]"
+        val actual = "[2, 2]"
+
+        assertExactMatch(expected, actual, ValueNotEqual("[*]"))
+    }
+
+    @Test
+    fun testValueNotEqual_withArraySingleNodeScope_passes() {
+        val expected = "[1, [1]]"
+        val actual = "[2, [1]]"
+
+        assertExactMatch(expected, actual, ValueNotEqual("*"))
+    }
+
+    @Test
+    fun testValueNotEqual_withArraySubtreeScope_passes() {
+        val expected = "[1, [1]]"
+        val actual = "[2, [2]]"
+
+        assertExactMatch(expected, actual, ValueNotEqual(Subtree))
+    }
 }


### PR DESCRIPTION

## Description

This PR creates a new JSON comparison path option that allows for specifying in the expected JSON that a value must have the same type but the literal values must be different.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
