### PR TITLE
Add `getPayloadJson` method to help convert NetworkRequest instances

### DIFF
--- a/code/testutils/src/main/java/com/adobe/marketing/mobile/util/TestUtils.java
+++ b/code/testutils/src/main/java/com/adobe/marketing/mobile/util/TestUtils.java
@@ -14,6 +14,7 @@ package com.adobe.marketing.mobile.util;
 import static com.adobe.marketing.mobile.util.TestConstants.LOG_TAG;
 
 import com.adobe.marketing.mobile.services.Log;
+import com.adobe.marketing.mobile.services.NetworkRequest;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -112,6 +113,26 @@ public class TestUtils {
 		} else if (jsonNode.isValueNode()) {
 			ValueNode valueNode = (ValueNode) jsonNode;
 			map.put(currentPath, valueNode.asText());
+		}
+	}
+
+	/**
+	 * Converts the body of a given {@link NetworkRequest} to a {@link JSONObject}.
+	 *
+	 * @param networkRequest The {@link NetworkRequest} containing the body to be converted. May be {@code null}.
+	 * @return A {@link JSONObject} representing the body of the {@link NetworkRequest}, or {@code null} if the body is {@code null} or cannot be converted.
+	 */
+	public static JSONObject getPayloadJson(NetworkRequest networkRequest) {
+		if (networkRequest == null || networkRequest.getBody() == null) {
+			return null;
+		}
+
+		String payload = new String(networkRequest.getBody());
+		try {
+			return new JSONObject(payload);
+		} catch (Exception e) {
+			Log.error(LOG_TAG, LOG_SOURCE, "Failed to create JSONObject from payload: " + e.getMessage());
+			return null;
 		}
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR add the `getPayloadJson` method to the `TestUtils` class to help convert `NetworkRequest` instances more easily to `JSONObject` instances for test use cases.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
