### PR TITLE
Add a wait time by default for getAllNetworkRequests()

### DIFF
--- a/code/testutils/src/main/java/com/adobe/marketing/mobile/util/MockNetworkService.kt
+++ b/code/testutils/src/main/java/com/adobe/marketing/mobile/util/MockNetworkService.kt
@@ -232,9 +232,12 @@ class MockNetworkService : Networking {
     }
 
     /**
-     * Immediately returns all sent network requests (if any) **without awaiting**.
+     * Returns all sent network requests (if any).
+     * If a timeout is specified (default is 2000 milliseconds), the function will wait for the specified time for the network requests to be recorded.
+     * If the timeout is set to 0, the function will immediately return the network requests without waiting.
      */
-    fun getAllNetworkRequests(): List<TestableNetworkRequest> {
+    fun getAllNetworkRequests(timeoutMillis: Int = TestConstants.Defaults.WAIT_NETWORK_REQUEST_TIMEOUT_MS): List<TestableNetworkRequest> {
+        TestHelper.waitForThreads(timeoutMillis)
         return helper.networkRequests
     }
 


### PR DESCRIPTION
Add a wait time by default for getAllNetworkRequests() in MockNetworkService.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
